### PR TITLE
Adding optional dynamic strength adjustment controls.

### DIFF
--- a/Config/FFBPlugin.ini
+++ b/Config/FFBPlugin.ini
@@ -43,6 +43,15 @@ AlternativeMaxForceLeft=-100
 AlternativeMinForceRight=0
 AlternativeMaxForceRight=100
 ForceShowDeviceGUIDMessageBox=0
+; Set to 1 if you want to enable dynamic strength adjustments, else 0.
+EnableFFBStrengthDynamicAdjustment=0
+; Button index for dynamically changing maximum FFB strength. 
+IncreaseFFBStrength=
+DecreaseFFBStrength=
+ResetFFBStrength=
+; Step is the amount to adjust when increasing or decreasing per button where FFB strength is represented on
+; a scale of 0-100.
+StepFFBStrength=5
 
 ; ***********************************************************************************************************************************
 ; ************************************************ Game overrides are specified below ***********************************************

--- a/Includes/FFBPluginReadme.txt
+++ b/Includes/FFBPluginReadme.txt
@@ -1,6 +1,6 @@
 ***FFB Arcade Plugin***
 
-Version 2.1
+Version 2.2
 
 Brought to you by Boomslangnz, Ducon2016, Spazzy & pinkimo.
 
@@ -181,4 +181,3 @@ extremely generous.
 -Virtua Racing (CHANGE TO UPRIGHT CABINET)
 -Wacky Races
 -Wangan Midnight Maximum Tune 5
--Le Mans 24


### PR DESCRIPTION
As discussed.

For Logitech G29 (with default buttons according to LGS drivers), map:
- Increase Button Index: 21
- Decrease Button Index: 22
- Reset Button Index: 23