### PR TITLE
Adding persistence to FFB Strength adjustments between loads.

### DIFF
--- a/Config/FFBPlugin.ini
+++ b/Config/FFBPlugin.ini
@@ -52,6 +52,12 @@ ResetFFBStrength=
 ; Step is the amount to adjust when increasing or decreasing per button where FFB strength is represented on
 ; a scale of 0-100.
 StepFFBStrength=5
+; Set to 1 if you want FFB strength adjustments to persist between loads, else 0.
+EnablePersistentMaxForce=0
+; 0-100: the previous max force strength set if persistence is enabled. -1 means this has not yet been saved.
+PersistentMaxForce=-1
+PersistentAlternativeMaxForceLeft=1
+PersistentAlternativeMaxForceRight=-1
 
 ; ***********************************************************************************************************************************
 ; ************************************************ Game overrides are specified below ***********************************************


### PR DESCRIPTION
Hi, I'm committing this without testing as I'm having difficulty building post updating to the latest changes (where the Demul changeVolume function was introduced), see below:

![image](https://user-images.githubusercontent.com/2965239/85237165-87e16100-b41c-11ea-9b0d-0add7721badb.png)

I'm hoping you can peer review the code and modify as you see fit.

**The basic concept** is to store the FFB Strength adjustments the user makes back to the FFBPlugin.ini so that upon next game load this strength is recalled. Without affecting the default MaxForce strength allowing resetting back to the original strength always.

Persistent values are loaded just after the FFB Strength adjustment loop (perhaps this should be before), if this value has never been set before.

Thanks!